### PR TITLE
Implemented the ability to mull to hand sizes below 5

### DIFF
--- a/hand.py
+++ b/hand.py
@@ -1,6 +1,7 @@
 import numpy as np
 from collections import Counter
 import scipy.stats as sps
+import itertools
 
 
 class Hand:
@@ -67,25 +68,20 @@ class Hand:
         self.size = sum(self.card_counts.values())
 
     def generate_subset_hands(self, numHide, noRemoveList = []):
-        if numHide > 2:
-            raise Exception('not implemented for more than 2')
         self.origHand = self.card_counts.copy()
         counterAsList = sorted(self.card_counts.elements())
-        self.subsetHands = []
-        for i in range(0, self.size):
-            if counterAsList[i] in noRemoveList:
-                continue
 
-            subHand = counterAsList[:i] + counterAsList[i+1:]
-            if numHide > 1:
-                for j in range(i, self.size-1):
-                    if counterAsList[i] in noRemoveList:
-                        continue
-                    subsubHand = subHand[:j] + subHand[j+1:]
-                    self.subsetHands.append(subsubHand)
-            else:
-                self.subsetHands.append(subHand)
+        handSubsets = list(itertools.combinations(counterAsList, self.size - numHide))
 
+        def equalNumberOfNotToBeRemovedCards(subsetHand, noRemoveList):
+            handCount = Counter(subsetHand)
+            for cardNameToNotBeRemoved in noRemoveList:
+                #if the number of cardName in the subset hand is less than the original hand
+                if(self.origHand[cardNameToNotBeRemoved] != handCount[cardNameToNotBeRemoved]):
+                    return False
+            return True
+
+        self.subsetHands = [x for x in handSubsets if equalNumberOfNotToBeRemovedCards(x, noRemoveList)]
         self.num_subsets = len(self.subsetHands)
         self.subsetIndex = -1
         self.size = self.size - numHide

--- a/mulliganTester.py
+++ b/mulliganTester.py
@@ -5,7 +5,7 @@ class MulliganTester(ABC):
     def __init__(self):
         self.iterations = 100000
         self.starting_size = 7
-        self.mullto = 5
+        self.mullto = 4
         self.resetCounters()
 
     @property
@@ -176,6 +176,7 @@ class MulliganTester(ABC):
                         handIndex = i
             i += 1
         if best is None:
+            #used for limited
             handIndex = self.pickBestHandSubset()
             if handIndex is not None:
                 best = results[handIndex]
@@ -198,6 +199,7 @@ class MulliganTester(ABC):
                 size = self.starting_size - j
                 self.hand.new_hand(self.starting_size)
                 drawn = False
+                #if not testing the 7
                 if j > 0:
                     subResults = []
                     self.hand.generate_subset_hands(j)
@@ -373,15 +375,19 @@ class MulliganTester(ABC):
             self.writeHandTypesToFile(file, p_good_afterTS, p_hands_afterTS)
 
             file.write("\n")
-            file.write("p of good hand by 5\n")
+            file.write("p of good hand by " + str(self.mullto) + "\n")
             file.write(str(p_success) + "\n")
             file.write("p of improvement after draw\n")
-            file.write("7,6,5\n")
+            for size in range(7,self.mullto-1,-1):
+                file.write(str(size) + ",")
+            file.write("\n")
             file.write(str(p_drawImprovement) + "\n")
             file.write("p of good hand after draw\n")
             file.write(str(p_successAfterDraw) + "\n\n")
             file.write("Thoughtseize Probabilities\n")
-            file.write("7,6,5,Hurt Keepable Hand\n")
+            for size in range(7,self.mullto-1,-1):
+                file.write(str(size) + ",")
+            file.write("Hurt Keepable Hand\n")
             file.write(str(p_TS_hurt) + "\n")
             file.write("Broke Keepable Hand\n")
             file.write(str(p_TS_broke) + "\n")


### PR DESCRIPTION
I wished to have the ability to mull to 4 and thought it best to just implement it for mulling to any number.
There might be a cleaner way of implementing the noRemoveList.

I also fixed up the print results method to print the number mulled to.