### PR TITLE
Draw card method seems to be incorrect

### DIFF
--- a/hand.py
+++ b/hand.py
@@ -1,6 +1,7 @@
 import numpy as np
 from collections import Counter
 import scipy.stats as sps
+import itertools
 
 
 class Hand:
@@ -67,25 +68,20 @@ class Hand:
         self.size = sum(self.card_counts.values())
 
     def generate_subset_hands(self, numHide, noRemoveList = []):
-        if numHide > 2:
-            raise Exception('not implemented for more than 2')
         self.origHand = self.card_counts.copy()
         counterAsList = sorted(self.card_counts.elements())
-        self.subsetHands = []
-        for i in range(0, self.size):
-            if counterAsList[i] in noRemoveList:
-                continue
 
-            subHand = counterAsList[:i] + counterAsList[i+1:]
-            if numHide > 1:
-                for j in range(i, self.size-1):
-                    if counterAsList[i] in noRemoveList:
-                        continue
-                    subsubHand = subHand[:j] + subHand[j+1:]
-                    self.subsetHands.append(subsubHand)
-            else:
-                self.subsetHands.append(subHand)
+        handSubsets = list(itertools.combinations(counterAsList, self.size - numHide))
 
+        def equalNumberOfNotToBeRemovedCards(subsetHand, noRemoveList):
+            handCount = Counter(subsetHand)
+            for cardNameToNotBeRemoved in noRemoveList:
+                #if the number of cardName in the subset hand is less than the original hand
+                if(self.origHand[cardNameToNotBeRemoved] != handCount[cardNameToNotBeRemoved]):
+                    return False
+            return True
+
+        self.subsetHands = [x for x in handSubsets if equalNumberOfNotToBeRemovedCards(x, noRemoveList)]
         self.num_subsets = len(self.subsetHands)
         self.subsetIndex = -1
         self.size = self.size - numHide

--- a/hand.py
+++ b/hand.py
@@ -93,12 +93,14 @@ class Hand:
 
     def draw_card(self, choice = None):
         if choice is None:
-            choice = np.random.choice(len(self.deck) - self.size, 1)[0]
+            choice = np.random.choice(len(self.deck), 1)[0]
 
-            if choice in self.draws:
-                choice = len(self.deck) - len(self.draws) + np.where(self.draws==choice)[0][0]
+            while choice in self.draws:
+                if(len(self.draws)>=len(self.deck)):
+                    raise Exception("Attempting to draw from an empty library.")
+                choice = np.random.choice(len(self.deck), 1)[0]
             
-            self.draws = np.append(self.draws, choice)
+        self.draws = np.append(self.draws, choice)
         
         self.lastDraw = self.deck[choice]
         self.card_counts[self.lastDraw] += 1

--- a/mulliganTester.py
+++ b/mulliganTester.py
@@ -5,7 +5,7 @@ class MulliganTester(ABC):
     def __init__(self):
         self.iterations = 100000
         self.starting_size = 7
-        self.mullto = 5
+        self.mullto = 4
         self.resetCounters()
 
     @property
@@ -176,6 +176,7 @@ class MulliganTester(ABC):
                         handIndex = i
             i += 1
         if best is None:
+            #used for limited
             handIndex = self.pickBestHandSubset()
             if handIndex is not None:
                 best = results[handIndex]
@@ -198,6 +199,7 @@ class MulliganTester(ABC):
                 size = self.starting_size - j
                 self.hand.new_hand(self.starting_size)
                 drawn = False
+                #if not testing the 7
                 if j > 0:
                     subResults = []
                     self.hand.generate_subset_hands(j)
@@ -373,15 +375,19 @@ class MulliganTester(ABC):
             self.writeHandTypesToFile(file, p_good_afterTS, p_hands_afterTS)
 
             file.write("\n")
-            file.write("p of good hand by 5\n")
+            file.write("p of good hand by " + str(self.mullto) + "\n")
             file.write(str(p_success) + "\n")
             file.write("p of improvement after draw\n")
-            file.write("7,6,5\n")
+            for size in range(7,self.mullto-1,-1):
+                file.write(str(size) + ",")
+            file.write("\n")
             file.write(str(p_drawImprovement) + "\n")
             file.write("p of good hand after draw\n")
             file.write(str(p_successAfterDraw) + "\n\n")
             file.write("Thoughtseize Probabilities\n")
-            file.write("7,6,5,Hurt Keepable Hand\n")
+            for size in range(7,self.mullto-1,-1):
+                file.write(str(size) + ",")
+            file.write("Hurt Keepable Hand\n")
             file.write(str(p_TS_hurt) + "\n")
             file.write("Broke Keepable Hand\n")
             file.write(str(p_TS_broke) + "\n")


### PR DESCRIPTION
I wanted to raise an issue but couldn't because this is a fork.

I am not sure if I am misunderstanding the functionality of the draw card method but the line 
`choice = np.random.choice(len(self.deck) - self.size, 1)[0]` 
Didn't seem to be working as intended because the deck is not ordered randomly so if you select from the deck length - hand size you will always miss the last cards of the deck when drawing a card.

I also could not understand what the following line was meant to do
`choice = len(self.deck) - len(self.draws) + np.where(self.draws==choice)[0][0]`
I rewrote the method to simply keep trying random numbers until you get one that hasn't been drawn before. This could potentially cause issues when trying to draw the entire deck as it could potentially fail this check repeatedly towards the last few cards however I expect the method will only be used to draw cards towards the top half of the deck in most use cases.

- Draw card method now pulls a random card from the whole of the deck rather than a subset of the deck based on hand size.
- If you try to draw more cards than there are in the library throw an exception.
- If you manually pass the choice in add that to the list of drawn cards.